### PR TITLE
Update pins_arduino.h

### DIFF
--- a/software/Arduino/hardware/watterott/avr/variants/tiny14/pins_arduino.h
+++ b/software/Arduino/hardware/watterott/avr/variants/tiny14/pins_arduino.h
@@ -31,14 +31,14 @@
 
 #include <avr/pgmspace.h>
 
-// ATMEL ATTINY84 / ARDUINO
+// ATMEL ATTINY841 / ARDUINO
 //
 //                           +-\/-+
 //                     VCC  1|    |14  GND
 //             (D 10)  PB0  2|    |13  PA0  (D  0)        AREF
-//             (D  9)  PB1  3|    |12  PA1  (D  1) 
+//      INT0   (D  9)  PB1  3|    |12  PA1  (D  1) 
 //                     PB3  4|    |11  PA2  (D  2) 
-//  PWM  INT0  (D  8)  PB2  5|    |10  PA3  (D  3) 
+//  PWM        (D  8)  PB2  5|    |10  PA3  (D  3) 
 //  PWM        (D  7)  PA7  6|    |9   PA4  (D  4) 
 //  PWM        (D  6)  PA6  7|    |8   PA5  (D  5)        PWM
 //                           +----+


### PR DESCRIPTION
Small errors i found. might not be all.
The pinout could be improved too in my opinion. However the PCBs are made now and I think you are not going to change it.

The Pinchangeinterrupt library should be compatible now with attiny841 as well (someone asked me)
https://github.com/NicoHood/PinChangeInterrupt/tree/dev

FYI there are missing definitions for the x41 in the io.h files: https://github.com/NicoHood/PinChangeInterrupt/commit/f81d538ce287561764811c9db3dee2fca9da0c66
